### PR TITLE
Allow 's3' as a variable and method name

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -20,6 +20,18 @@ LongParameterList:
   exclude:
   - initialize
 
+# Dislikes method names ending in a number (Like `test2`, etc...) But, these
+# are the names of actual AWS services, and it is common to have the variables
+# named the same.
+UncommunicativeMethodName:
+  accept:
+    - s3
+    - ec2
+UncommunicativeVariableName:
+  accept:
+    - s3
+    - ec2
+
 "app/controllers":
   NestedIterators:
     max_allowed_nesting: 2


### PR DESCRIPTION
I think this rule is preventing names like `test1`, `test2`, etc. But in this case, s3 is a perfectly valid name
