### PR TITLE
AS::Subscriber objects don't have FeatureEnvy

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -32,6 +32,12 @@ UncommunicativeVariableName:
     - s3
     - ec2
 
+# AS::Subscriber objects tend to rely heavily on `event` and `payload`, so its
+# hard to avoid "Feature Envy", but is prefectly readable.
+FeatureEnvy:
+  exclude:
+    - !ruby/regexp /Subscriber/
+
 "app/controllers":
   NestedIterators:
     max_allowed_nesting: 2


### PR DESCRIPTION
An example:

```
def dump_table(event)
  payload = event.payload
  log event, "Dumping table %s (%d rows, %s in %02.fms)" % [payload[:model],
                                                            payload[:tuples],
                                                            payload[:bytes].to_s(:human_size),
                                                            event.duration]
end
```

This calls `event` and `payload` many times, but such is the nature of a
subscriber method.
