### PR TITLE
Reversed LeadingZero rule for scss lint

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -5,3 +5,5 @@ linters:
     max_depth: 4
   PropertySortOrder:
     order: recess
+  LeadingZero:
+    style: include_zero


### PR DESCRIPTION
Leading zero should be preferred because that's the way human beings read decimals.
