### PR TITLE
Allow braces around last parameter if previous parameter is a Hash.

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -28,6 +28,8 @@ AllCops:
   TargetRubyVersion: 2.3
 Style/AndOr:
   EnforcedStyle: conditionals
+Style/BracesAroundHashParameters:
+  EnforcedStyle: context_dependent
 Style/CaseIndentation:
   IndentOneStep: true
 Style/Documentation:


### PR DESCRIPTION
It is common to see something like this in a spec:

```
expect(notifications).to contain_exactly({ adapter_name: described_class.name.to_s,
                                           request_type: :delete_export_definition,
                                           export_uri: uri },
                                         { adapter_name: described_class.name.to_s,
                                           request_type: :delete_export,
                                           export_uri: uri })
```

Rubocop will complain about the last parameter, suggesting the braces should
be removed.  I think this hinders readability.

Per the rubocop docs:
- The `context_dependent` style checks that the last parameter doesn't have
  braces around it, but requires braces if the second to last parameter is
  also a hash literal.
