### PR TITLE
Updated `config.reek` for migrations.

### DIFF
--- a/config.reek
+++ b/config.reek
@@ -46,6 +46,11 @@ FeatureEnvy:
 "app/helpers":
   UtilityFunction:
     enabled: false
+"db/migrate":
+  TooManyStatements:
+    enabled: false
+  FeatureEnvy:
+    enabled: false
 "spec/support":
   UtilityFunction:
     enabled: false


### PR DESCRIPTION
- Relaxed some rules for migrations.  It's common
  to have many statements if you have a lot of columns
  and indices. Also, you always refer to the `table`
  which triggers the `FeatureEnvy` complaint.