### PR TITLE
require brackets for an array of symbols

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -42,6 +42,8 @@ Style/ExtraSpacing:
 Style/HashSyntax:
   Exclude:
     - "lib/tasks/**/*"
+Style/SymbolArray:
+  EnforcedStyle: brackets
 Style/MultilineOperationIndentation:
   EnforcedStyle: indented
 Style/NumericLiterals:


### PR DESCRIPTION
Having an array of symbols using the symbol notation, it
is much clearer to the developer that these are symbols
than an i% or I% notation.

Example:

```ruby
ARR = [
  :create,
  :update,
  :delete
].freeze
```

vs

```ruby
ARR = I%[
  create
  update
  delete
].freeze
```
  