### PR TITLE
require brackets for word arrays

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -95,6 +95,8 @@ Style/ExtraSpacing:
     - "bin/**/*"
   Exclude:
     - "config/routes.rb"
+Style/WordArray:
+  EnforcedStyle: brackets
 Lint/PercentStringArray:
   Exclude:
     # SecureHeaders needs the single quotes in `%w[https: 'self']`


### PR DESCRIPTION
the downside to requiring the `w%[]` syntax for word
arrays is that as soon as a single item in that array
gets a space you have to update how the array is defined.
Aside from being an annoyance, it makes for a noisier
git diff that makes reviews more difficult.

Example:

```ruby
ALLOWED_VALUES = w%[dog cat bird].freeze

ALLOWED_VALUES = ['dog', 'cat', 'bird', 'favorite dog'].freeze
```