### PR TITLE
Added one more ignore path to fix `spec_helper` grep false positive

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -64,6 +64,8 @@ plugins:
     enabled: false # turn back on if they start supporting yarn.lock
   grep:
     enabled: true
+    exclude_patterns:
+    - "**/spec_helper.rb"
     config:
       patterns:
         no-dot-only:


### PR DESCRIPTION
I think we are done, Napa is green now in https://github.com/kapost/napa/pull/6047