### PR TITLE
Updated common with the new scsslint already copied to all apps

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,9 +1,20 @@
 linters:
-  SelectorDepth:
-    max_depth: 4
-  NestingDepth:
-    max_depth: 4
+  StringQuotes:
+    enabled: true
+    style: double_quotes
   PropertySortOrder:
     order: recess
   LeadingZero:
     style: include_zero
+  NestingDepth:
+    ignore_parent_selectors: true
+    max_depth: 4
+  HexNotation:
+    style: uppercase
+  HexLength:
+    style: long
+
+exclude:
+  - "**/vendor/**"
+  - "**/node_modules/**"
+  - "node_modules/**"


### PR DESCRIPTION
Forgot to update this with the other files. Going to merge as this was already agreed upon and copied to every app. Watercress was the only app with difficulty going to these rules and an auto fix solved most of those ordering issues.