### PR TITLE
require top-level documentation

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -33,7 +33,7 @@ Style/BracesAroundHashParameters:
 Style/CaseIndentation:
   IndentOneStep: true
 Style/Documentation:
-  Enabled: false
+  Enabled: true
 Style/EachWithObject:
   Enabled: false
 Style/ExtraSpacing:


### PR DESCRIPTION
I'm sure some people _hate_ this, but hear me out 🙂

my argument for this is twofold:

1. While line or method-level functionality changes quickly,
leading to stale comments, class-level functionality is
much more static.

2. Self-documenting code is a must for a readable codebase, but
code is not perfectly self-documenting. Often self-documenting
code does a better job of explaining what one method does than
of what the class as a whole is responsible for. Class/module-level
documentation helps people understanding the higher-level
functionality of an object, speeding up their ability to grok a
larger system.