### PR TITLE
Update eslint with async-await function spacing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -127,7 +127,11 @@ module.exports = {
       }
     ],
     // We prefer no spaces as we already warn with function declaration without names.
-    "space-before-function-paren": ["error", "never"],
+    "space-before-function-paren": ["error", {
+      "anonymous": "never",
+      "named": "never",
+      "asyncArrow": "always",
+    }],
   },
 
   overrides: [


### PR DESCRIPTION
## Overview

This updates our function spacing to lint "properly" for the `async`/`await` keywords. None of the weeds apps have been using this, but I ran into this when starting up Osaka.

Without this change, the linter would want anonymous async functions to look like the following :

```js
const myAsyncFunc = async() => {
  // ...
};
```

IMO, the spacing is confusing as it looks like a function call. With the change here, it would be preferred to have the following style:


```js
const myAsyncFunc = async () => {
  // ...
};
```

If the function is a non-arrow named function, this shouldn't have an effect.

```js
async function myAsyncFunction() {
  // ...
}
```

We already diverge from airbnb here for function spacing. AirBnb doesn't use async/await yet, so this is on us.

## Before merge:

Nothing. We can merge this at any time as no apps are using async/await outside of Osaka (which is already using this update) and this does not affect any other linting in existing apps.