### PR TITLE
Relax destructuring rules for arrays

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -99,6 +99,19 @@ module.exports = {
     "no-unused-vars": ["error", { vars: "all", args: "all", argsIgnorePattern: "^_" }],
     // We allow the developer to decide what is best for readability, only looking for consistency
     "object-curly-newline": ["error", { "consistent": true }],
+    // We don't require array destructuring like airbnb
+    "prefer-destructuring": ["error", {
+      VariableDeclarator: {
+        array: false,
+        object: true,
+      },
+      AssignmentExpression: {
+        array: false,
+        object: true,
+      },
+    }, {
+      enforceForRenamedProperties: false,
+    }],
     // We stick with double quotes to be consistent with ruby and keep to our muscle memory
     "quotes": ["error", "double", { "avoidEscape": true }],
     // We do not care if react is within .js or .jsx extensions, unlike airbnb.


### PR DESCRIPTION
## Overview

Per our discussion in slack (#frontend-engineering), we talked about relaxing the destructuring rule Airbnb provides so it does not affect arrays. It's still ok to destructure arrays (and many times can help readability!), but we opt to let the developer decide as it can be awkward in some cases. It also allows the developer to access 

Without the change:

```js
// Arrays
let x;
x = someArray[0]; // error: prefer destructuring
[x] = someArray; // all good

// more extreme
x = someArray[4]; // error: prefer destructuring
[, , , , x]= someArray; // all good

const [y, ...rest] = someArray; // all good
```

After the change:

```js
// Arrays
let x;
x = someArray[0]; // all good
[x] = someArray; // all good

// more extreme
x = someArray[4]; // all good
[, , , , x]= someArray; // all good (but please don't)


const [y, ...rest] = someArray; // all good
```

You might notice the other object config. That was already there from Airbnb. The only time we ask to  destructuring now is if the variable is named one-to-one with the object key. This helps group variables extracted and helps us reduce lines. Object config is unchanged and works like the below:


```js

// Objects (unchanged)
const id = initiative.id; // error: prefer destructuring
const title = initiative.title; // error: prefer destructuring

const { id, title } = initiative; // all good

const myId1 = initiative.id; // all good (renamed)
```