### PR TITLE
Disabled arrow-parens to allow developer to decide

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,6 +39,8 @@ module.exports = {
   rules: {
     // We let the developer decide on whether to add arrow function braces or not, as it is a readability judgement.
     "arrow-body-style": "off",
+    // We also let the developer decide when to add parens. This is nicer for flow with single-arity function chains.
+    "arrow-parens": "off",
     // More reasonable comma-dangle config (only when we get a benefit in git diff). Functions are a bit ugly so we ignore comma dangle
     // (allowing the developer to determine readability).
     "comma-dangle": [


### PR DESCRIPTION
This relaxed the arrow paren rule, which was inconsistent at best. This was especially annoying with "flow" like, chained functions with single-arity.

Without this change:

```js
const myFunc = x => y => { // error: use parens with block
  return x + y;
};

const myFunc = x => (y) => { // all good (but gross)
  return x + y;
};

const myFunc = (x) => (y) => { // error: use parens only as needed :(
  return x + y;
};
```


After this change:

```js
const myFunc = x => y => { // all good
  return x + y;
};

const myFunc = x => (y) => { // all good (but please don't)
  return x + y;
};

const myFunc = (x) => (y) => { // all good
  return x + y;
};
```