### PR TITLE
Disable ambiguous blocks in specs.

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -26,6 +26,9 @@ Rails/TimeZone:
   Enabled: false
 AllCops:
   TargetRubyVersion: 2.3
+Lint/AmbiguousBlockAssociation:
+  Exclude:
+    - "spec/**/*"
 Style/AndOr:
   EnforcedStyle: conditionals
 Style/BracesAroundHashParameters:


### PR DESCRIPTION
Currently, we get rubocop linter issues for code like this
```
  it "does not clone manage access defaults" do
    expect { perform_action }.to_not change { Racl::Default.count }
  end
```

This is valid rspec syntax and should not trigger a linter error.

See https://github.com/bbatsov/rubocop/issues/4222 for a conversation about this same issue, which triggered a change to the default rubocop configuration.