### PR TITLE
Disabled eslint consistent-return

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -53,6 +53,8 @@ module.exports = {
     ],
     // We are stricter with complexity
     "complexity": ["error", 6],
+    // There are enough cases where this is more annoying than helpful (React components)
+    "consistent-return": "off",
     // We allow the developer to decide what is best for readability, only looking for consistency
     "function-paren-newline": ["error", "consistent"],
     // Adjust extension warnings, allowing json to be imported.


### PR DESCRIPTION
Opening this for discussion: This rule is helpful for catching some logic bugs, but there are enough cases where the "undefined" return is something that is desired. 


Common examples where we use it:

**React:**

```js
renderSubThing: () => { // error: consistent return
  if (this.props.show) {
     return <div>something</div>;
  }
}
```


**Lodash `mergeWith`**

```js
function customizer(objValue, srcValue) { // error: consistent return
  if (_.isArray(objValue)) {
    return objValue.concat(srcValue);
  }
}
 
const object = { a: [1], b: [2] };
const other = { a: [3], b: [4] };
 
_.mergeWith(object, other, customizer);
```


Both of these warn and need to be disabled when used as they are valid. In the second example, returning `null` would be incorrect so there's no way to make correct code without disabling a rule. I believe we should just turn it off, as it's more trouble that it is worth from a "bug catching" perspective.


EDIT: I should note that returning undefined from a component will break, so we do run the risk of bugs with the inconsistency in renderMethods, where `render*` can return undefined or null, but `render` cannot return `undefined`.