### PR TITLE
do not autocorrect safe navigation

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -110,3 +110,5 @@ Lint/PercentStringArray:
 Style/SignalException:
   Description: "Checks for proper usage of fail and raise."
   Enabled: false
+Style/SafeNavigation:
+  AutoCorrect: false # safe navigation autocorrect can easily create bad logic


### PR DESCRIPTION
The autocorrect behavior doesn't know the specifics of the logic. Here's an example. Before, if there is no user, we get `false` if the `user_id` is `nil`. But after autocorrect we would get true, because both sides evaluate to `nil`.

```ruby
# before
user && user.id == user_id
# after autocorrect
user&.id == user_id
```