### PR TITLE
Disabled react/forbid-prop-types

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -118,6 +118,8 @@ module.exports = {
     }],
     // We stick with double quotes to be consistent with ruby and keep to our muscle memory
     "quotes": ["error", "double", { "avoidEscape": true }],
+    // This rule has good intentions and is a generally good idea, but too overbearing.
+    "react/forbid-prop-types": ["off"],
     // We do not care if react is within .js or .jsx extensions, unlike airbnb.
     "react/jsx-filename-extension": ["error", { extensions: [".js", ".jsx"] }],
     // While this rule would be nice--it doesn't work correctly right now.


### PR DESCRIPTION
Opening up for discussion—I'm not 100% on this one. This rule encourages developers to use `shape` to build better prop types. This is a good idea, but can get overbearing. It's especially annoying when passing down props several layers.

Example now:

```
static propTypes = {
  dateRange: object.isRequired, // error: react/forbid-prop-types: use shape instead
}
```

To solve this on large component trees, we have extracted out shapes and used them down the component tree. This is good, again I see this rule as a general positive but calling it a issue is probably overkill. Curious what others think about moving this to a "best practice" rather than a codeclimate issue.