### PR TITLE
use slashes for regex

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -110,3 +110,6 @@ Style/SignalException:
   Enabled: false
 Style/SafeNavigation:
   AutoCorrect: false # safe navigation autocorrect can easily create bad logic
+Style/RegexpLiteral:
+  AllowInnerSlashes: true
+  EnforcedStyle: slashes


### PR DESCRIPTION
slashes are common across languages.

```ruby
/(.*?)/
```

the percent-r convention is a Ruby specific convention, and arguably
not even a dominant convention.

```ruby
%r[(.*?)]
```