### PR TITLE
do not check block length in spec files

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -20,6 +20,11 @@ AllCops:
 
 Metrics/LineLength:
   Max: 120
+Metrics/BlockLength:
+  Enabled: true
+  Exclude:
+    - spec/**/*
+    - test/**/*
 Rails/Date:
   Enabled: false
 Rails/TimeZone:


### PR DESCRIPTION
RSpec holds all testing logic in a block, meaning
this rule is broken for almost every test file.