### PR TITLE
do not require class documentation in specs

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -37,6 +37,9 @@ Layout/CaseIndentation:
   IndentOneStep: true
 Style/Documentation:
   Enabled: true
+  Exclude:
+    - "spec/**/*"
+    - "test/**/*"
 Style/EachWithObject:
   Enabled: false
 Style/HashSyntax:


### PR DESCRIPTION
classes defined in tests are not part of the business logic
and mostly mocks and fakes, for which documentation is
of insufficient value to justify this check.