### PR TITLE
[refactor] exclude no-spec rules from all specs

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -23,8 +23,8 @@ Metrics/LineLength:
 Metrics/BlockLength:
   Enabled: true
   Exclude:
-    - spec/**/*
-    - test/**/*
+    - "**/spec/**/*"
+    - "**/test/**/*"
 Rails/Date:
   Enabled: false
 Rails/TimeZone:
@@ -33,7 +33,8 @@ AllCops:
   TargetRubyVersion: 2.3
 Lint/AmbiguousBlockAssociation:
   Exclude:
-    - "spec/**/*"
+    - "**/spec/**/*"
+    - "**/test/**/*"
 Style/AndOr:
   EnforcedStyle: conditionals
 Style/BracesAroundHashParameters:
@@ -42,6 +43,9 @@ Layout/CaseIndentation:
   IndentOneStep: true
 Style/Documentation:
   Enabled: true
+  Exclude:
+    - "**/spec/**/*"
+    - "**/test/**/*"
 Style/EachWithObject:
   Enabled: false
 Style/HashSyntax:
@@ -68,7 +72,8 @@ Style/StringLiterals:
   EnforcedStyle: double_quotes
 Layout/MultilineMethodCallIndentation:
   Exclude:
-    - "spec/**/*.rb"
+    - "**/spec/**/*"
+    - "**/test/**/*"
 
 # These are better handled by reek
 Metrics/MethodLength:


### PR DESCRIPTION
The `spec/**/*` exclusion misses local engines and gems. `**/spec/**/*` should correctly ignore all the spec files in all the locations we might have.