### PR TITLE
Use "consistent" style for array indents

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -55,6 +55,8 @@ Style/SymbolArray:
   EnforcedStyle: brackets
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+Layout/IndentArray:
+  EnforcedStyle: consistent
 Style/NumericLiterals:
   Enabled: false
 Style/PercentLiteralDelimiters:


### PR DESCRIPTION
[Here is the cop documentation](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Layout/IndentArray). This should help keep line lengths down and make the code more readable. If folks want more flexibility we could also stop enforcing this.

tldr: enforce array argument spacing like this:

```ruby
and_in_a_method_call([
  :no_difference
])
```

Not like this:

```ruby
but_in_a_method_call([
                       :its_like_this
                     ])
```