### PR TITLE
Consistent braces requirements for hash parameters

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -38,7 +38,7 @@ Lint/AmbiguousBlockAssociation:
 Style/AndOr:
   EnforcedStyle: conditionals
 Style/BracesAroundHashParameters:
-  EnforcedStyle: context_dependent
+  EnforcedStyle: braces
 Layout/CaseIndentation:
   IndentOneStep: true
 Style/Documentation:

--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -38,7 +38,7 @@ Lint/AmbiguousBlockAssociation:
 Style/AndOr:
   EnforcedStyle: conditionals
 Style/BracesAroundHashParameters:
-  EnforcedStyle: braces
+  Enabled: false
 Layout/CaseIndentation:
   IndentOneStep: true
 Style/Documentation:


### PR DESCRIPTION
[Docs for the cop are here](https://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Style/BracesAroundHashParameters). My argument is that braces make it very clear what the argument is, and don't leave interpretation to the magic of the MRI. This also simplifies the cognitive overhead of coding, where you don't have to stop to think "should this hash argument have braces or not?". It always should.

As always, if folks have differing opinions we could also stop enforcing this entirely.

tldr: always require braces around the final argument of a method if it is a hash. like this:

```ruby
some_method(x, y, {a: 1, b: 2})
```
Not like this:

```ruby
some_method(x, y, a: 1, b: 2)
```