### PR TITLE
Updated `.eslintrc.js` to prefer named exports over default exports.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,11 +70,13 @@ module.exports = {
     "import/first": ["error", { "absolute-first": false }],
     // We should be using es2015 imports in all modern .js and .jsx files
     "import/no-commonjs": "error",
+    "import/no-default-export": "warn",    
     // We expect imports to be sorted by the convention we have been keeping to in the weeds.
     "import/order": ["warn", {
       "groups": ["builtin", "external", "internal", "parent", "sibling"],
       "newlines-between": "always-and-inside-groups",
     }],
+    "import/prefer-default-export": "off",
     // We turn on max lines
     "max-lines": ["error", {
       max: 300,


### PR DESCRIPTION
-  See: https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-default-export.md
- By using named exports, we can more easily import code and keep to consistent naming.
- Editors and tooling works better with named items.

## Screenshot
- When the same rules are applied to napaweed.

![eslint](https://user-images.githubusercontent.com/1525033/68715878-3573c400-0560-11ea-9d9e-d517bb3f6783.png)
