### PR TITLE
Updates `rubocop` and `reek`

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -3,46 +3,29 @@
 # similar as possible to ease maintainability. Instead, open a PR in the
 # codeclimate-common repo at https://github.com/kapost/codeclimate-common
 
-Rails:
-  Enabled: true
-
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true
-  Include:
-    - "**/Rakefile"
-    - "**/config.ru"
   Exclude:
     - "vendor/**/*"
     - "spec/fixtures/**/*"
     - "bin/**/*"
     - "script/**/*"
-
-Metrics/LineLength:
-  Max: 120
 Metrics/BlockLength:
   Enabled: true
   Exclude:
     - "**/spec/**/*"
     - "**/test/**/*"
-Rails/Date:
-  Enabled: false
-Rails/TimeZone:
-  Enabled: false
-AllCops:
-  TargetRubyVersion: 2.3
 Lint/AmbiguousBlockAssociation:
   Exclude:
     - "**/spec/**/*"
     - "**/test/**/*"
 Style/AndOr:
   EnforcedStyle: conditionals
-Style/BracesAroundHashParameters:
-  Enabled: false
 Layout/CaseIndentation:
   IndentOneStep: true
 Style/Documentation:
-  Enabled: true
+  Enabled: false
   Exclude:
     - "**/spec/**/*"
     - "**/test/**/*"
@@ -53,10 +36,18 @@ Style/HashSyntax:
     - "lib/tasks/**/*"
 Style/SymbolArray:
   EnforcedStyle: brackets
+Layout/LineLength:
+  Max: 120
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
-Layout/IndentArray:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
 Style/NumericLiterals:
   Enabled: false
 Style/PercentLiteralDelimiters:
@@ -68,12 +59,8 @@ Style/PercentLiteralDelimiters:
     "%r": "()"
 Style/RegexpLiteral:
   Enabled: false
-Style/SignalException:
-  EnforcedStyle: semantic
 Style/SingleLineBlockParams:
   Enabled: false
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
 Layout/MultilineMethodCallIndentation:
   Enabled: false
 # These are better handled by reek
@@ -100,15 +87,13 @@ Layout/LeadingCommentSpace:
 Layout/SpaceInsideParens:
   Exclude:
     - "bin/**/*"
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   Exclude:
     - "bin/**/*"
 Layout/ExtraSpacing:
   Exclude:
     - "config/routes.rb"
     - "bin/**/*"
-  Exclude:
-    - "config/routes.rb"
 Style/WordArray:
   EnforcedStyle: brackets
 Lint/PercentStringArray:

--- a/config.reek
+++ b/config.reek
@@ -3,63 +3,66 @@
 # similar as possible to ease maintainability. Instead, open a PR in the
 # codeclimate-common repo at https://github.com/kapost/codeclimate-common
 
-UtilityFunction:
-  public_methods_only: true
-  exclude:
-  - perform # Exclude Sidekiq/ActiveJob "perform" methods, which are stateless.
-
-TooManyStatements:
-  exclude:
-  - initialize
-  max_statements: 8
-
-RepeatedConditional:
-  max_ifs: 4
-
-LongParameterList:
-  exclude:
-  - initialize
-
-# Dislikes method names ending in a number (Like `test2`, etc...) But, these
-# are the names of actual AWS services, and it is common to have the variables
-# named the same.
-UncommunicativeMethodName:
-  accept:
-    - s3
-    - ec2
-UncommunicativeVariableName:
-  accept:
-    - s3
-    - ec2
-
-# AS::Subscriber objects tend to rely heavily on `event` and `payload`, so its
-# hard to avoid "Feature Envy", but is prefectly readable.
-FeatureEnvy:
-  exclude:
-    - !ruby/regexp /Subscriber/
-
-"app/controllers":
-  NestedIterators:
-    max_allowed_nesting: 2
-  UnusedPrivateMethod:
-    enabled: false
-"app/helpers":
-  UtilityFunction:
-    enabled: false
-"db/migrate":
-  TooManyStatements:
-    enabled: false
+detectors:
+  # ActiveSupport::Subscriber objects tend to rely heavily on `event` and `payload`, so it's
+  # hard to avoid "Feature Envy", but is prefectly readable.
   FeatureEnvy:
+    exclude:
+      - "/Subscriber/"
+
+  IrresponsibleModule:
     enabled: false
-"spec/support":
+
+  LongParameterList:
+    exclude:
+    - initialize
+    - perform
+
+  RepeatedConditional:
+    max_ifs: 4
+
+  TooManyStatements:
+    exclude:
+    - initialize
+    max_statements: 8
+
+  # Dislikes method names ending in a number (Like `test2`, etc...) But, these
+  # are the names of actual AWS services, and it is common to have the variables
+  # named the same.
+  UncommunicativeMethodName:
+    accept:
+      - s3
+      - ec2
+
+  # Oftentimes it makes sense to namespace groups of versioned components "V2", "V1"
+  UncommunicativeModuleName:
+    accept:
+      - "/V[0-9]$/"
+
+  UncommunicativeVariableName:
+    accept:
+      - s3
+      - ec2
+
   UtilityFunction:
-    enabled: false
+    public_methods_only: true
+    exclude:
+    - perform # Exclude Sidekiq/ActiveJob "perform" methods, which are stateless.
 
-# This one just makes sure the Class/Module has a comment. Dumb.
-IrresponsibleModule:
-  enabled: false
-
-# Oftentimes it makes sense to namespace groups of versioned components "V2", "V1"
-UncommunicativeModuleName:
-  accept:
-    - !ruby/regexp /V[0-9]$/
+directories:
+  "app/controllers":
+    NestedIterators:
+      max_allowed_nesting: 2
+    UnusedPrivateMethod:
+      enabled: false
+  "app/helpers":
+    UtilityFunction:
+      enabled: false
+  "db/migrate":
+    TooManyStatements:
+      enabled: false
+    FeatureEnvy:
+      enabled: false
+  "spec/support":
+    UtilityFunction:
+      enabled: false


### PR DESCRIPTION
### Overview
- Updated to the latest formats for these gems.
- For details see https://github.com/kapost/napa/pull/9085
- The config is currently aligned.